### PR TITLE
Document Department + print format

### DIFF
--- a/kalima/kalima/doctype/academic_semester/academic_semester.json
+++ b/kalima/kalima/doctype/academic_semester/academic_semester.json
@@ -11,7 +11,8 @@
   "start",
   "finish",
   "apply_available",
-  "credit_range_time"
+  "credit_range_time",
+  "document_department"
  ],
  "fields": [
   {
@@ -49,11 +50,17 @@
    "fieldtype": "Table",
    "label": "Credit Range Time",
    "options": "Credit Range Time"
+  },
+  {
+   "fieldname": "document_department",
+   "fieldtype": "Link",
+   "label": "Document Department",
+   "options": "Department"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-06-10 13:01:40.871081",
+ "modified": "2024-08-26 15:40:41.962961",
  "modified_by": "Administrator",
  "module": "Kalima",
  "name": "Academic Semester",

--- a/kalima/kalima/doctype/activity/activity.json
+++ b/kalima/kalima/doctype/activity/activity.json
@@ -26,7 +26,8 @@
   "amended_from",
   "activity_deliverers",
   "is_published",
-  "route"
+  "route",
+  "document_department"
  ],
  "fields": [
   {
@@ -161,6 +162,12 @@
    "fieldtype": "Table",
    "label": "General Participants",
    "options": "General Participants"
+  },
+  {
+   "fieldname": "document_department",
+   "fieldtype": "Link",
+   "label": "Document Department",
+   "options": "Department"
   }
  ],
  "has_web_view": 1,
@@ -168,7 +175,7 @@
  "is_published_field": "is_published",
  "is_submittable": 1,
  "links": [],
- "modified": "2024-08-24 15:12:25.212298",
+ "modified": "2024-08-26 15:32:37.332155",
  "modified_by": "Administrator",
  "module": "Kalima",
  "name": "Activity",

--- a/kalima/kalima/doctype/activity_announcement/activity_announcement.json
+++ b/kalima/kalima/doctype/activity_announcement/activity_announcement.json
@@ -10,6 +10,7 @@
   "title",
   "date",
   "activity_deliverers",
+  "document_department",
   "column_break_dltw",
   "description",
   "section_break_ilot",
@@ -89,12 +90,18 @@
    "fieldname": "participants_type",
    "fieldtype": "Data",
    "label": "Participants Type"
+  },
+  {
+   "fieldname": "document_department",
+   "fieldtype": "Link",
+   "label": "Document Department",
+   "options": "Department"
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-08-03 13:05:37.043058",
+ "modified": "2024-08-26 15:38:27.469740",
  "modified_by": "Administrator",
  "module": "Kalima",
  "name": "Activity Announcement",

--- a/kalima/kalima/doctype/activity_certificate/activity_certificate.json
+++ b/kalima/kalima/doctype/activity_certificate/activity_certificate.json
@@ -15,7 +15,8 @@
   "amended_from",
   "template_section",
   "template",
-  "description"
+  "description",
+  "document_department"
  ],
  "fields": [
   {
@@ -75,12 +76,18 @@
    "fieldname": "description",
    "fieldtype": "Text Editor",
    "label": "Description"
+  },
+  {
+   "fieldname": "document_department",
+   "fieldtype": "Link",
+   "label": "Document Department",
+   "options": "Department"
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-07-27 10:49:25.091549",
+ "modified": "2024-08-26 15:44:48.343625",
  "modified_by": "Administrator",
  "module": "Kalima",
  "name": "Activity Certificate",

--- a/kalima/kalima/doctype/activity_coordination/activity_coordination.json
+++ b/kalima/kalima/doctype/activity_coordination/activity_coordination.json
@@ -9,7 +9,8 @@
   "request",
   "venue",
   "activity_requirements",
-  "amended_from"
+  "amended_from",
+  "document_department"
  ],
  "fields": [
   {
@@ -41,12 +42,18 @@
    "print_hide": 1,
    "read_only": 1,
    "search_index": 1
+  },
+  {
+   "fieldname": "document_department",
+   "fieldtype": "Link",
+   "label": "Document Department",
+   "options": "Department"
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-07-06 13:33:44.314992",
+ "modified": "2024-08-26 15:42:20.747207",
  "modified_by": "Administrator",
  "module": "Kalima",
  "name": "Activity Coordination",

--- a/kalima/kalima/doctype/activity_request/activity_request.json
+++ b/kalima/kalima/doctype/activity_request/activity_request.json
@@ -22,7 +22,8 @@
   "participants_type",
   "departments",
   "staff_activity_list",
-  "amended_from"
+  "amended_from",
+  "document_department"
  ],
  "fields": [
   {
@@ -128,12 +129,18 @@
    "fieldtype": "Link",
    "label": "Template",
    "options": "Terms and Conditions"
+  },
+  {
+   "fieldname": "document_department",
+   "fieldtype": "Link",
+   "label": "Document Department",
+   "options": "Department"
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-08-07 13:40:05.057428",
+ "modified": "2024-08-26 15:36:52.491256",
  "modified_by": "Administrator",
  "module": "Kalima",
  "name": "Activity Request",

--- a/kalima/kalima/doctype/applicant_student/applicant_student.json
+++ b/kalima/kalima/doctype/applicant_student/applicant_student.json
@@ -36,6 +36,7 @@
   "legal_guardian_name",
   "relation",
   "occupation",
+  "document_department",
   "column_break_pxgg",
   "mobile_no",
   "guardian_email",
@@ -754,11 +755,17 @@
    "fieldtype": "Data",
    "label": "Initial Password",
    "read_only": 1
+  },
+  {
+   "fieldname": "document_department",
+   "fieldtype": "Link",
+   "label": "Document Department",
+   "options": "Department"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-08-24 15:13:01.409230",
+ "modified": "2024-08-26 15:31:14.772117",
  "modified_by": "Administrator",
  "module": "Kalima",
  "name": "Applicant Student",

--- a/kalima/kalima/doctype/book/book.json
+++ b/kalima/kalima/doctype/book/book.json
@@ -33,6 +33,7 @@
   "remark",
   "isbn",
   "right_to_use",
+  "document_department",
   "column_break_gpak",
   "ebook_file",
   "barcode",
@@ -214,13 +215,19 @@
    "fieldtype": "Data",
    "label": "Route",
    "read_only": 1
+  },
+  {
+   "fieldname": "document_department",
+   "fieldtype": "Link",
+   "label": "Document Department",
+   "options": "Department"
   }
  ],
  "has_web_view": 1,
  "index_web_pages_for_search": 1,
  "is_published_field": "is_published",
  "links": [],
- "modified": "2024-08-03 15:32:55.436770",
+ "modified": "2024-08-26 15:37:55.890225",
  "modified_by": "Administrator",
  "module": "Kalima",
  "name": "Book",

--- a/kalima/kalima/doctype/book_category/book_category.json
+++ b/kalima/kalima/doctype/book_category/book_category.json
@@ -11,7 +11,8 @@
   "lft",
   "rgt",
   "is_group",
-  "parent_book_category"
+  "parent_book_category",
+  "document_department"
  ],
  "fields": [
   {
@@ -57,12 +58,18 @@
    "ignore_user_permissions": 1,
    "label": "Parent Book Category",
    "options": "Book Category"
+  },
+  {
+   "fieldname": "document_department",
+   "fieldtype": "Link",
+   "label": "Document Department",
+   "options": "Department"
   }
  ],
  "index_web_pages_for_search": 1,
  "is_tree": 1,
  "links": [],
- "modified": "2024-07-25 11:10:03.570262",
+ "modified": "2024-08-26 15:44:59.012530",
  "modified_by": "Administrator",
  "module": "Kalima",
  "name": "Book Category",

--- a/kalima/kalima/doctype/borrowing_limitations/borrowing_limitations.json
+++ b/kalima/kalima/doctype/borrowing_limitations/borrowing_limitations.json
@@ -9,6 +9,7 @@
   "undergraduate_student",
   "phd_student",
   "employee",
+  "document_department",
   "column_break_xaln",
   "master_student",
   "teacher",
@@ -48,12 +49,18 @@
    "fieldname": "special",
    "fieldtype": "Int",
    "label": "Special"
+  },
+  {
+   "fieldname": "document_department",
+   "fieldtype": "Link",
+   "label": "Document Department",
+   "options": "Department"
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2024-06-10 13:30:11.712388",
+ "modified": "2024-08-26 15:40:02.701222",
  "modified_by": "Administrator",
  "module": "Kalima",
  "name": "Borrowing Limitations",

--- a/kalima/kalima/doctype/class/class.json
+++ b/kalima/kalima/doctype/class/class.json
@@ -27,7 +27,8 @@
   "column_break_hpag",
   "student_list",
   "section_break_jhbz",
-  "class_modules"
+  "class_modules",
+  "document_department"
  ],
  "fields": [
   {
@@ -162,11 +163,17 @@
    "fieldname": "disabled",
    "fieldtype": "Check",
    "label": "Disabled"
+  },
+  {
+   "fieldname": "document_department",
+   "fieldtype": "Link",
+   "label": "Document Department",
+   "options": "Department"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-08-07 11:19:38.578204",
+ "modified": "2024-08-26 15:36:08.655688",
  "modified_by": "Administrator",
  "module": "Kalima",
  "name": "Class",

--- a/kalima/kalima/doctype/class_continuous_exam/class_continuous_exam.json
+++ b/kalima/kalima/doctype/class_continuous_exam/class_continuous_exam.json
@@ -18,7 +18,8 @@
   "marked_on",
   "module",
   "section_break_gahv",
-  "continuous_exam_result"
+  "continuous_exam_result",
+  "document_department"
  ],
  "fields": [
   {
@@ -90,11 +91,17 @@
    "fieldtype": "Link",
    "label": "Module",
    "options": "Presented Module"
+  },
+  {
+   "fieldname": "document_department",
+   "fieldtype": "Link",
+   "label": "Document Department",
+   "options": "Department"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-08-08 16:01:32.896830",
+ "modified": "2024-08-26 15:35:52.145837",
  "modified_by": "Administrator",
  "module": "Kalima",
  "name": "Class Continuous Exam",

--- a/kalima/kalima/doctype/class_session/class_session.json
+++ b/kalima/kalima/doctype/class_session/class_session.json
@@ -11,6 +11,7 @@
   "title",
   "issue_date",
   "expiration_date",
+  "document_department",
   "column_break_inyc",
   "description",
   "section_break_ymqp",
@@ -65,11 +66,17 @@
   {
    "fieldname": "section_break_ymqp",
    "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "document_department",
+   "fieldtype": "Link",
+   "label": "Document Department",
+   "options": "Department"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-07-10 13:48:26.983651",
+ "modified": "2024-08-26 15:39:43.268739",
  "modified_by": "Administrator",
  "module": "Kalima",
  "name": "Class Session",

--- a/kalima/kalima/doctype/class_timetable/class_timetable.json
+++ b/kalima/kalima/doctype/class_timetable/class_timetable.json
@@ -14,6 +14,7 @@
   "column_break_oimt",
   "start",
   "finish",
+  "document_department",
   "section_break_cvsm",
   "description"
  ],
@@ -83,11 +84,17 @@
    "fieldtype": "Data",
    "in_list_view": 1,
    "label": "Module Name"
+  },
+  {
+   "fieldname": "document_department",
+   "fieldtype": "Link",
+   "label": "Document Department",
+   "options": "Department"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-08-24 14:57:34.796039",
+ "modified": "2024-08-26 15:33:09.658806",
  "modified_by": "Administrator",
  "module": "Kalima",
  "name": "Class Timetable",

--- a/kalima/kalima/doctype/classroom/classroom.json
+++ b/kalima/kalima/doctype/classroom/classroom.json
@@ -8,6 +8,7 @@
  "field_order": [
   "name1",
   "capacity",
+  "document_department",
   "column_break_cppp",
   "columns",
   "building"
@@ -39,11 +40,17 @@
    "fieldtype": "Link",
    "label": "Building",
    "options": "Building"
+  },
+  {
+   "fieldname": "document_department",
+   "fieldtype": "Link",
+   "label": "Document Department",
+   "options": "Department"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-06-25 11:14:03.414195",
+ "modified": "2024-08-26 15:40:15.234219",
  "modified_by": "Administrator",
  "module": "Kalima",
  "name": "Classroom",

--- a/kalima/kalima/doctype/complaints/complaints.json
+++ b/kalima/kalima/doctype/complaints/complaints.json
@@ -11,7 +11,8 @@
   "column_break_wvoi",
   "department",
   "section_break_fsrg",
-  "message"
+  "message",
+  "document_department"
  ],
  "fields": [
   {
@@ -47,11 +48,17 @@
    "fieldtype": "Link",
    "label": "Department",
    "options": "Department"
+  },
+  {
+   "fieldname": "document_department",
+   "fieldtype": "Link",
+   "label": "Document Department",
+   "options": "Department"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-07-24 16:36:23.504745",
+ "modified": "2024-08-26 15:45:11.115045",
  "modified_by": "Administrator",
  "module": "Kalima",
  "name": "Complaints",

--- a/kalima/kalima/doctype/constant/constant.json
+++ b/kalima/kalima/doctype/constant/constant.json
@@ -18,7 +18,8 @@
   "entrance_type",
   "academic_system_type",
   "start",
-  "end"
+  "end",
+  "document_department"
  ],
  "fields": [
   {
@@ -104,11 +105,17 @@
    "label": "Type",
    "options": "Percentage\nFixed Amount",
    "reqd": 1
+  },
+  {
+   "fieldname": "document_department",
+   "fieldtype": "Link",
+   "label": "Document Department",
+   "options": "Department"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-06-23 12:46:20.104133",
+ "modified": "2024-08-26 15:38:54.918782",
  "modified_by": "Administrator",
  "module": "Kalima",
  "name": "Constant",

--- a/kalima/kalima/doctype/department_module/department_module.json
+++ b/kalima/kalima/doctype/department_module/department_module.json
@@ -17,7 +17,8 @@
   "type",
   "credit",
   "prerequisites_section",
-  "prerequisite_modules"
+  "prerequisite_modules",
+  "document_department"
  ],
  "fields": [
   {
@@ -98,11 +99,17 @@
    "label": "Academic System Type",
    "options": "Coursat\nBologna\nAnnual",
    "reqd": 1
+  },
+  {
+   "fieldname": "document_department",
+   "fieldtype": "Link",
+   "label": "Document Department",
+   "options": "Department"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-08-07 14:59:53.054664",
+ "modified": "2024-08-26 15:36:34.691542",
  "modified_by": "Administrator",
  "module": "Kalima",
  "name": "Department Module",

--- a/kalima/kalima/doctype/dormitory/dormitory.json
+++ b/kalima/kalima/doctype/dormitory/dormitory.json
@@ -14,7 +14,8 @@
   "section_break_dkvz",
   "hostel",
   "room",
-  "amended_from"
+  "amended_from",
+  "document_department"
  ],
  "fields": [
   {
@@ -72,12 +73,18 @@
    "fieldname": "room",
    "fieldtype": "Select",
    "label": "Room"
+  },
+  {
+   "fieldname": "document_department",
+   "fieldtype": "Link",
+   "label": "Document Department",
+   "options": "Department"
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-07-06 13:24:28.242342",
+ "modified": "2024-08-26 15:44:32.578469",
  "modified_by": "Administrator",
  "module": "Kalima",
  "name": "Dormitory",

--- a/kalima/kalima/doctype/exam_hall_distribution/exam_hall_distribution.json
+++ b/kalima/kalima/doctype/exam_hall_distribution/exam_hall_distribution.json
@@ -14,6 +14,7 @@
   "from_time",
   "to_time",
   "distribution_type",
+  "document_department",
   "section_break_tgcd",
   "exam_departments",
   "students_section",
@@ -117,12 +118,18 @@
    "print_hide": 1,
    "read_only": 1,
    "search_index": 1
+  },
+  {
+   "fieldname": "document_department",
+   "fieldtype": "Link",
+   "label": "Document Department",
+   "options": "Department"
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-07-06 14:15:44.602459",
+ "modified": "2024-08-26 15:35:27.430105",
  "modified_by": "Administrator",
  "module": "Kalima",
  "name": "Exam Hall Distribution",

--- a/kalima/kalima/doctype/exam_questions/exam_questions.json
+++ b/kalima/kalima/doctype/exam_questions/exam_questions.json
@@ -16,6 +16,7 @@
   "first_round_selected_prototype",
   "second_round_selected_prototype",
   "third_round_selected_prototype",
+  "document_department",
   "section_break_xega",
   "prototype_1",
   "prototype_2",
@@ -130,12 +131,18 @@
   {
    "fieldname": "column_break_mjhw",
    "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "document_department",
+   "fieldtype": "Link",
+   "label": "Document Department",
+   "options": "Department"
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-07-25 10:22:09.898880",
+ "modified": "2024-08-26 15:45:48.518096",
  "modified_by": "Administrator",
  "module": "Kalima",
  "name": "Exam Questions",

--- a/kalima/kalima/doctype/exam_result_entry/exam_result_entry.json
+++ b/kalima/kalima/doctype/exam_result_entry/exam_result_entry.json
@@ -10,6 +10,7 @@
   "department",
   "class",
   "attempt",
+  "document_department",
   "column_break_vmdf",
   "module",
   "stage",
@@ -86,11 +87,17 @@
    "fieldtype": "Select",
    "label": "Academic System Type",
    "options": "Coursat\nBologna\nAnnual"
+  },
+  {
+   "fieldname": "document_department",
+   "fieldtype": "Link",
+   "label": "Document Department",
+   "options": "Department"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-07-17 14:46:03.995342",
+ "modified": "2024-08-26 15:46:36.520500",
  "modified_by": "Administrator",
  "module": "Kalima",
  "name": "Exam Result Entry",

--- a/kalima/kalima/doctype/exam_schedule/exam_schedule.json
+++ b/kalima/kalima/doctype/exam_schedule/exam_schedule.json
@@ -8,7 +8,8 @@
  "field_order": [
   "class",
   "date",
-  "time"
+  "time",
+  "document_department"
  ],
  "fields": [
   {
@@ -31,11 +32,17 @@
    "fieldtype": "Time",
    "label": "Time",
    "reqd": 1
+  },
+  {
+   "fieldname": "document_department",
+   "fieldtype": "Link",
+   "label": "Document Department",
+   "options": "Department"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-07-06 13:45:22.383901",
+ "modified": "2024-08-26 15:41:17.881240",
  "modified_by": "Administrator",
  "module": "Kalima",
  "name": "Exam Schedule",

--- a/kalima/kalima/doctype/faculty/faculty.json
+++ b/kalima/kalima/doctype/faculty/faculty.json
@@ -9,6 +9,7 @@
   "english_title",
   "arabic_title",
   "abbreviation_title",
+  "document_department",
   "column_break_hemz",
   "code",
   "dean_hr_department",
@@ -60,11 +61,17 @@
    "fieldtype": "Check",
    "label": "Is Active",
    "reqd": 1
+  },
+  {
+   "fieldname": "document_department",
+   "fieldtype": "Link",
+   "label": "Document Department",
+   "options": "Department"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-05-28 11:47:24.955356",
+ "modified": "2024-08-26 15:39:29.802738",
  "modified_by": "Administrator",
  "module": "Kalima",
  "name": "Faculty",

--- a/kalima/kalima/doctype/fines/fines.json
+++ b/kalima/kalima/doctype/fines/fines.json
@@ -9,6 +9,7 @@
   "book",
   "number",
   "due_date",
+  "document_department",
   "column_break_epfx",
   "amount",
   "user",
@@ -48,16 +49,22 @@
    "options": "Paid\nUnpaid\nPartialy Paid"
   },
   {
-   "fetch_from": "book.number",
+   "fetch_from": "book.serial_number",
    "fieldname": "number",
    "fieldtype": "Int",
    "label": "Number",
    "read_only": 1
+  },
+  {
+   "fieldname": "document_department",
+   "fieldtype": "Link",
+   "label": "Document Department",
+   "options": "Department"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-06-29 15:39:46.793586",
+ "modified": "2024-08-26 15:44:06.641513",
  "modified_by": "Administrator",
  "module": "Kalima",
  "name": "Fines",

--- a/kalima/kalima/doctype/hostel/hostel.json
+++ b/kalima/kalima/doctype/hostel/hostel.json
@@ -13,6 +13,7 @@
   "administrator",
   "section_break_rkvs",
   "address",
+  "document_department",
   "column_break_pdxr",
   "rooms_list"
  ],
@@ -65,11 +66,17 @@
    "fieldtype": "Table",
    "label": "Rooms List",
    "options": "Rooms List"
+  },
+  {
+   "fieldname": "document_department",
+   "fieldtype": "Link",
+   "label": "Document Department",
+   "options": "Department"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-06-10 13:00:00.830444",
+ "modified": "2024-08-26 15:42:45.302360",
  "modified_by": "Administrator",
  "module": "Kalima",
  "name": "Hostel",

--- a/kalima/kalima/doctype/incoming/incoming.json
+++ b/kalima/kalima/doctype/incoming/incoming.json
@@ -14,6 +14,7 @@
   "column_break_pzva",
   "sender",
   "amended_from",
+  "document_department",
   "section_break_kjri",
   "template",
   "description",
@@ -96,12 +97,18 @@
    "fieldtype": "Link",
    "label": "Template",
    "options": "Terms and Conditions"
+  },
+  {
+   "fieldname": "document_department",
+   "fieldtype": "Link",
+   "label": "Document Department",
+   "options": "Department"
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-07-24 16:37:58.687173",
+ "modified": "2024-08-26 15:45:30.390172",
  "modified_by": "Administrator",
  "module": "Kalima",
  "name": "Incoming",

--- a/kalima/kalima/doctype/lend_book/lend_book.json
+++ b/kalima/kalima/doctype/lend_book/lend_book.json
@@ -13,6 +13,7 @@
   "user",
   "loaned_person_name",
   "is_returned",
+  "document_department",
   "column_break_sbra",
   "lending_date",
   "return_date",
@@ -73,6 +74,7 @@
    "read_only_depends_on": "eval:doc.is_returned == 1"
   },
   {
+   "default": "0",
    "fetch_from": "fining_system.period",
    "fieldname": "extra_period",
    "fieldtype": "Data",
@@ -132,12 +134,18 @@
    "fieldtype": "Date",
    "label": "Lending Date",
    "options": "User"
+  },
+  {
+   "fieldname": "document_department",
+   "fieldtype": "Link",
+   "label": "Document Department",
+   "options": "Department"
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-08-03 13:08:05.025483",
+ "modified": "2024-08-26 15:38:09.838058",
  "modified_by": "Administrator",
  "module": "Kalima",
  "name": "Lend Book",

--- a/kalima/kalima/doctype/library/library.json
+++ b/kalima/kalima/doctype/library/library.json
@@ -9,6 +9,7 @@
   "title",
   "faculty",
   "description",
+  "document_department",
   "column_break_qkzn",
   "library_users"
  ],
@@ -39,11 +40,17 @@
    "fieldtype": "Table",
    "label": "Library users",
    "options": "Library Users"
+  },
+  {
+   "fieldname": "document_department",
+   "fieldtype": "Link",
+   "label": "Document Department",
+   "options": "Department"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-07-27 15:01:43.711038",
+ "modified": "2024-08-26 15:43:00.218056",
  "modified_by": "Administrator",
  "module": "Kalima",
  "name": "Library",

--- a/kalima/kalima/doctype/outgoing/outgoing.json
+++ b/kalima/kalima/doctype/outgoing/outgoing.json
@@ -13,6 +13,7 @@
   "column_break_udxe",
   "document_number",
   "amended_from",
+  "document_department",
   "section_break_hlnd",
   "template",
   "description",
@@ -129,12 +130,18 @@
    "fieldtype": "Link",
    "label": "Template",
    "options": "Terms and Conditions"
+  },
+  {
+   "fieldname": "document_department",
+   "fieldtype": "Link",
+   "label": "Document Department",
+   "options": "Department"
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-07-24 16:39:10.959751",
+ "modified": "2024-08-26 15:46:06.492219",
  "modified_by": "Administrator",
  "module": "Kalima",
  "name": "Outgoing",

--- a/kalima/kalima/doctype/question_prototype/question_prototype.json
+++ b/kalima/kalima/doctype/question_prototype/question_prototype.json
@@ -9,6 +9,7 @@
   "section_break_pqvw",
   "module",
   "teacher",
+  "document_department",
   "column_break_leui",
   "exam_max_mark",
   "amended_from",
@@ -64,12 +65,18 @@
    "fieldname": "exam_max_mark",
    "fieldtype": "Float",
    "label": "Exam Max Mark"
+  },
+  {
+   "fieldname": "document_department",
+   "fieldtype": "Link",
+   "label": "Document Department",
+   "options": "Department"
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-08-04 11:48:25.826124",
+ "modified": "2024-08-26 15:37:31.707999",
  "modified_by": "Administrator",
  "module": "Kalima",
  "name": "Question Prototype",

--- a/kalima/kalima/doctype/research/research.json
+++ b/kalima/kalima/doctype/research/research.json
@@ -12,6 +12,7 @@
   "publishing_channel",
   "status",
   "attachments",
+  "document_department",
   "column_break_drrj",
   "description"
  ],
@@ -57,11 +58,17 @@
    "fieldname": "description",
    "fieldtype": "Text Editor",
    "label": "Description"
+  },
+  {
+   "fieldname": "document_department",
+   "fieldtype": "Link",
+   "label": "Document Department",
+   "options": "Department"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-07-02 14:45:13.690611",
+ "modified": "2024-08-26 15:41:02.107008",
  "modified_by": "Administrator",
  "module": "Kalima",
  "name": "Research",

--- a/kalima/kalima/doctype/student/student.json
+++ b/kalima/kalima/doctype/student/student.json
@@ -76,6 +76,7 @@
   "employer_address",
   "notes_section",
   "notes",
+  "document_department",
   "study_info_tab",
   "current_info_section",
   "status",
@@ -860,11 +861,17 @@
    "fieldname": "module_visualization",
    "fieldtype": "HTML",
    "label": "Module Visualization"
+  },
+  {
+   "fieldname": "document_department",
+   "fieldtype": "Link",
+   "label": "Document Department",
+   "options": "Department"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-08-24 15:13:18.081811",
+ "modified": "2024-08-26 15:30:50.466248",
  "modified_by": "Administrator",
  "module": "Kalima",
  "name": "Student",

--- a/kalima/kalima/doctype/student_attendance_entry/student_attendance_entry.json
+++ b/kalima/kalima/doctype/student_attendance_entry/student_attendance_entry.json
@@ -12,6 +12,7 @@
   "academic_system_type",
   "semester",
   "department",
+  "document_department",
   "column_break_wvoi",
   "module",
   "presented_module_old",
@@ -100,11 +101,17 @@
    "fieldtype": "Select",
    "label": "Academic System Type",
    "options": "Coursat\nBologna\nAnnual"
+  },
+  {
+   "fieldname": "document_department",
+   "fieldtype": "Link",
+   "label": "Document Department",
+   "options": "Department"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-07-22 13:50:32.183761",
+ "modified": "2024-08-26 15:46:25.442943",
  "modified_by": "Administrator",
  "module": "Kalima",
  "name": "Student Attendance Entry",

--- a/kalima/kalima/doctype/student_exam_result/student_exam_result.json
+++ b/kalima/kalima/doctype/student_exam_result/student_exam_result.json
@@ -11,6 +11,7 @@
   "student",
   "year",
   "module",
+  "document_department",
   "column_break_chsn",
   "teacher",
   "stage",
@@ -147,12 +148,18 @@
    "fieldtype": "Select",
    "label": "Academic System Type",
    "options": "Coursat\nBologna\nAnnual"
+  },
+  {
+   "fieldname": "document_department",
+   "fieldtype": "Link",
+   "label": "Document Department",
+   "options": "Department"
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-07-17 14:53:35.559993",
+ "modified": "2024-08-26 15:47:07.743265",
  "modified_by": "Administrator",
  "module": "Kalima",
  "name": "Student Exam Result",

--- a/kalima/kalima/doctype/student_fee_structure/student_fee_structure.json
+++ b/kalima/kalima/doctype/student_fee_structure/student_fee_structure.json
@@ -16,6 +16,7 @@
   "semester",
   "study_system",
   "amended_from",
+  "document_department",
   "fees_section",
   "fee_amount",
   "study_type",
@@ -157,12 +158,18 @@
    "fieldtype": "Select",
    "label": "Academic System Type",
    "options": "Coursat\nBologna\nAnnual"
+  },
+  {
+   "fieldname": "document_department",
+   "fieldtype": "Link",
+   "label": "Document Department",
+   "options": "Department"
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-07-17 14:47:03.934299",
+ "modified": "2024-08-26 15:46:47.484188",
  "modified_by": "Administrator",
  "module": "Kalima",
  "name": "Student Fee Structure",

--- a/kalima/kalima/doctype/student_result_log/student_result_log.json
+++ b/kalima/kalima/doctype/student_result_log/student_result_log.json
@@ -13,6 +13,7 @@
   "module",
   "stage",
   "academic_system_type",
+  "document_department",
   "column_break_chsn",
   "type",
   "teacher",
@@ -327,13 +328,19 @@
    "fieldtype": "Select",
    "label": "Final Exam Type",
    "options": "\nCourse Final Exam\nAnnual Final Exam\nAnnual Half Year Exam"
+  },
+  {
+   "fieldname": "document_department",
+   "fieldtype": "Link",
+   "label": "Document Department",
+   "options": "Department"
   }
  ],
  "in_create": 1,
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-08-04 12:54:11.302445",
+ "modified": "2024-08-26 15:37:18.672187",
  "modified_by": "Administrator",
  "module": "Kalima",
  "name": "Student Result Log",

--- a/kalima/kalima/doctype/students_fees/students_fees.json
+++ b/kalima/kalima/doctype/students_fees/students_fees.json
@@ -26,6 +26,7 @@
   "fee_amount",
   "fee_study_type",
   "payment_term",
+  "document_department",
   "section_break_fuet",
   "students_fees",
   "addon_fees",
@@ -214,6 +215,12 @@
    "fieldtype": "Table",
    "label": "Addon Fees",
    "options": "Addon Fees"
+  },
+  {
+   "fieldname": "document_department",
+   "fieldtype": "Link",
+   "label": "Document Department",
+   "options": "Department"
   }
  ],
  "index_web_pages_for_search": 1,
@@ -224,7 +231,7 @@
    "link_fieldname": "custom_student_fee"
   }
  ],
- "modified": "2024-08-24 14:39:09.503504",
+ "modified": "2024-08-26 15:34:59.657544",
  "modified_by": "Administrator",
  "module": "Kalima",
  "name": "Students Fees",

--- a/kalima/kalima/doctype/transfer/transfer.json
+++ b/kalima/kalima/doctype/transfer/transfer.json
@@ -12,6 +12,7 @@
   "department",
   "date",
   "file",
+  "document_department",
   "column_break_ecom",
   "year",
   "system_type",
@@ -93,12 +94,18 @@
    "print_hide": 1,
    "read_only": 1,
    "search_index": 1
+  },
+  {
+   "fieldname": "document_department",
+   "fieldtype": "Link",
+   "label": "Document Department",
+   "options": "Department"
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-07-06 12:07:06.505399",
+ "modified": "2024-08-26 15:43:20.438120",
  "modified_by": "Administrator",
  "module": "Kalima",
  "name": "Transfer",


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Add a 'Document Department' field to various document types in the Kalima module to enable linking with the 'Department' entity, enhancing the organizational structure and data management.

New Features:
- Introduce a new 'Document Department' field across multiple document types, allowing linkage to the 'Department' entity.

<!-- Generated by sourcery-ai[bot]: end summary -->